### PR TITLE
fix critical performance downgrade when push new branch

### DIFF
--- a/pre-receive.sh
+++ b/pre-receive.sh
@@ -45,26 +45,17 @@ function main() {
       continue
     fi
 
-    # check for new branches
-    local target="${oldref}..${newref}"
-    if [[ "$oldref" == "$NULLSHA" ]]; then
-      # try to find an existing ancestor
-      local fp
-      fp="$(find_ancestor "$newref")"
-      if [[ "$?" == 0 ]]; then
-        # use the existing ancestor as base
-        target="${fp}..${newref}"
-      else
-        # otherwise check all objects in that branch
-        target="${newref}"
-      fi
-    fi
-
     # find large objects
     local large_files
-    large_files="$(git rev-list --objects "$target" | \
-      git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' | \
-      awk -v maxbytes="$maxsize" '$3 > maxbytes { print $4 }')"
+    if [[ "$oldref" == "$NULLSHA" ]]; then
+      large_files="$(git rev-list --objects "$newref" --not --branches=* | \
+        git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' | \
+        awk -v maxbytes="$maxsize" '$3 > maxbytes { print $4 }')"
+    else
+      large_files="$(git rev-list --objects "${oldref}..${newref}" | \
+        git cat-file --batch-check='%(objectname) %(objecttype) %(objectsize) %(rest)' | \
+        awk -v maxbytes="$maxsize" '$3 > maxbytes { print $4 }')"
+    fi
     if [[ "$?" != 0 ]]; then
       echo "failed to check for large files in ref ${refname}"
       continue
@@ -86,60 +77,6 @@ function main() {
   done
 
   exit "$status"
-}
-
-# find a suitable ancestor to decide which objects to check
-function find_ancestor() {
-  local newref="$1"
-
-  # query all existing references
-  local refs
-  refs="$(git show-ref --heads -s)"
-  if [[ "$?" != 0 ]]; then
-    return "$EXIT_FAILURE"
-  fi
-
-  # check existing references for possible fork points
-  local fps=""
-  local ref
-  for ref in $refs; do
-    local fp
-    fp="$(git merge-base "$ref" "$newref")"
-    if [[ "$?" != 0 ]]; then
-      continue
-    fi
-
-    # update / replace existing fork points
-    local other
-    for other in $fps; do
-      local rval
-      git merge-base --is-ancestor "$fp" "$other"
-      rval="$?"
-      if [[ "$rval" == 0 ]]; then
-        # skip if current fork point is an ancestor
-        continue 2
-      elif [[ "$rval" == 1 ]]; then
-        # replace if current fork point is a successor
-        fps="$(echo ${fps/$other} ${fp})"
-        continue 2
-      else
-        # ignore errors
-        :
-      fi
-    done
-
-    # add fork point
-    fps="$(echo ${fps} ${fp})"
-  done
-
-  # select first fork point
-  # in the very rare case that multiple fork points are found that are not
-  # related to each other, simple choose the first one as a starting point.
-  if [[ -z "$fps" ]]; then
-    return "$EXIT_FAILURE"
-  fi
-  printf "%s\n" $fps | head -n 1
-  return "$EXIT_SUCCESS"
 }
 
 # get the maximum filesize configured for this repository or the default


### PR DESCRIPTION
fix find_ancestor find wrong ancestor caused useless
iteration on checked commits.

Environment:
GitLab 10.8.3
Git 2.7.0
Git LFS 2.4.0

I have a repository with 41000+ commits and 100+GiB size. When I push a new branch to server, I found that it takes about 50+ seconds to complete. After disabled pre-receive hook the time has been downgrade to 3+ seconds.

And I found find_ancestor method has performance issues. So I just replace it with normal git command `git rev-list --objects "$newref" --not --branches=* ` to escape this problem. I think the parameter `--not --branches=*` is good enough.

After I replaced it and pushed new branch to server, this time it only takes 4+ seconds to complete.
And I have also tested `push --delete origin branch` to delete remote branch, push normal commits in existing branch, push commits which contains large file in existing branch. It works well.

So I think it should be ok to merge this fix.